### PR TITLE
Fixing Travis-CI build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: java
-jdk:
-  - oraclejdk8
+
+addons:
+  apt:
+    sources:
+      - sourceline: 'deb http://repos.azulsystems.com/ubuntu stable main'
+        key_url: 'http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems'
+    packages:
+      - zulu-8
 
 after_success:
   - mvn clean test jacoco:report org.eluder.coveralls:coveralls-maven-plugin:jacoco -DsourceEncoding=UTF-8

--- a/kotlin-support/pom.xml
+++ b/kotlin-support/pom.xml
@@ -14,7 +14,7 @@
         <jsr.version>1.0</jsr.version>
         <ri.version>1.0</ri.version>
         <!-- dependency versions -->
-        <kotlin.version>1.1.2</kotlin.version>
+        <kotlin.version>1.5.0</kotlin.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
- Oracle JDK 8 is no longer available at Travis-CI (license restrictions)
  - Switching to Zulu JDK 8 solves this issue
- Kotlin 1.1.2 is not working in the build (`KotlinFrontEndException`)
  - Switching to Kotlin 1.5.0 solves this issue

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javamoney/javamoney-shelter/39)
<!-- Reviewable:end -->
