### PR TITLE
Add CoinbaseRateProvider implementation to address issue #3

### DIFF
--- a/crypto-currency/bitcoin/pom.xml
+++ b/crypto-currency/bitcoin/pom.xml
@@ -166,6 +166,11 @@
 			<type>pom</type>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.5.14</version>
+		</dependency>
 	</dependencies>
 
   <repositories>

--- a/crypto-currency/bitcoin/src/main/java/org/javamoney/shelter/bitcoin/provider/CoinbaseRateProvider.java
+++ b/crypto-currency/bitcoin/src/main/java/org/javamoney/shelter/bitcoin/provider/CoinbaseRateProvider.java
@@ -62,8 +62,7 @@ public class CoinbaseRateProvider extends AbstractRateProvider {
     }
 
     private void loadSupportedCurrencies() {
-        try {
-            HttpClient httpClient = HttpClient.newHttpClient();
+        try (HttpClient httpClient = HttpClient.newHttpClient()){
             String url = "https://api.coinbase.com/v2/currencies";
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))
@@ -79,8 +78,7 @@ public class CoinbaseRateProvider extends AbstractRateProvider {
     }
 
     private void loadRates() {
-        try {
-            HttpClient httpClient = HttpClient.newHttpClient();
+        try (HttpClient httpClient = HttpClient.newHttpClient()){
             String url = "https://api.coinbase.com/v2/exchange-rates?currency=" + DEFAULT_BASE_CURRENCY;
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))

--- a/crypto-currency/bitcoin/src/main/java/org/javamoney/shelter/bitcoin/provider/CoinbaseRateProvider.java
+++ b/crypto-currency/bitcoin/src/main/java/org/javamoney/shelter/bitcoin/provider/CoinbaseRateProvider.java
@@ -7,6 +7,7 @@ import org.javamoney.moneta.spi.AbstractRateProvider;
 import org.javamoney.moneta.spi.DefaultNumberValue;
 
 import javax.money.CurrencyUnit;
+import javax.money.MonetaryException;
 import javax.money.convert.*;
 import java.io.IOException;
 import java.net.URI;
@@ -14,11 +15,9 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.ArrayList;
-import java.util.Currency;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Logger;
 
 public class CoinbaseRateProvider extends AbstractRateProvider {
     private static final RateType RATE_TYPE = RateType.DEFERRED;
@@ -29,8 +28,6 @@ public class CoinbaseRateProvider extends AbstractRateProvider {
 
     private final List<String> supportedCurrencies = new ArrayList<>();
     private final Map<String, Number> rates = new ConcurrentHashMap<>();
-
-    private final Logger log = Logger.getLogger(getClass().getName());
 
     public CoinbaseRateProvider() {
         super(CONTEXT);
@@ -77,7 +74,7 @@ public class CoinbaseRateProvider extends AbstractRateProvider {
             JsonNode dataNode = jsonNode.get("data");
             dataNode.forEach(node -> supportedCurrencies.add(node.get("id").asText()));
         } catch (IOException | InterruptedException e) {
-            log.severe("Failed to load supported currencies from Coinbase API: " + e.getMessage());
+            throw new MonetaryException("Failed to load supported currencies from Coinbase API", e);
         }
     }
 
@@ -94,7 +91,7 @@ public class CoinbaseRateProvider extends AbstractRateProvider {
             JsonNode ratesNode = jsonNode.get("data").get("rates");
             ratesNode.fields().forEachRemaining(entry -> rates.put(entry.getKey(), entry.getValue().asDouble()));
         } catch (IOException | InterruptedException e) {
-            log.severe("Failed to load exchange rates from Coinbase API: " + e.getMessage());
+            throw new MonetaryException("Failed to load exchange rates from Coinbase API", e);
         }
     }
 }

--- a/crypto-currency/bitcoin/src/main/java/org/javamoney/shelter/bitcoin/provider/CoinbaseRateProvider.java
+++ b/crypto-currency/bitcoin/src/main/java/org/javamoney/shelter/bitcoin/provider/CoinbaseRateProvider.java
@@ -1,0 +1,97 @@
+package org.javamoney.shelter.bitcoin.provider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.javamoney.moneta.convert.ExchangeRateBuilder;
+import org.javamoney.moneta.spi.AbstractRateProvider;
+import org.javamoney.moneta.spi.DefaultNumberValue;
+
+import javax.money.convert.*;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
+
+public class CoinbaseRateProvider extends AbstractRateProvider {
+    private static final RateType RATE_TYPE = RateType.DEFERRED;
+    private static final ProviderContext CONTEXT = ProviderContextBuilder.of("CoinbaseRateProvider", RATE_TYPE)
+            .set("providerDescription", "Coinbase - Bitcoin exchange rate provider")
+            .build();
+    private static final String DEFAULT_BASE_CURRENCY = "BTC";
+
+    private final List<String> supportedCurrencies = new ArrayList<>();
+    private final Map<String, Number> rates = new ConcurrentHashMap<>();
+
+    private final Logger log = Logger.getLogger(getClass().getName());
+
+    public CoinbaseRateProvider() {
+        super(CONTEXT);
+        loadSupportedCurrencies();
+    }
+
+    @Override
+    public ExchangeRate getExchangeRate(ConversionQuery conversionQuery) {
+        var baseCurrency = conversionQuery.getBaseCurrency();
+        var termCurrency = conversionQuery.getCurrency();
+        var conversionContext = ConversionContext.of(getContext().getProviderName(), RATE_TYPE);
+
+        if (!DEFAULT_BASE_CURRENCY.equals(baseCurrency.getCurrencyCode())) {
+            throw new CurrencyConversionException(baseCurrency, termCurrency, conversionContext, "Base currency not supported: " + baseCurrency);
+        }
+
+        if (!supportedCurrencies.contains(termCurrency.getCurrencyCode())) {
+            throw new CurrencyConversionException(baseCurrency, termCurrency, conversionContext, "Term currency not supported: " + termCurrency);
+        }
+
+        loadRates();
+
+        var rate = rates.get(termCurrency.getCurrencyCode());
+        if (rate == null) {
+            throw new CurrencyConversionException(baseCurrency, termCurrency, conversionContext, "Rate not available for currency: " + termCurrency);
+        }
+        return new ExchangeRateBuilder(conversionContext)
+                .setBase(baseCurrency)
+                .setTerm(termCurrency)
+                .setFactor(DefaultNumberValue.of(rate))
+                .build();
+    }
+
+    private void loadSupportedCurrencies() {
+        try {
+            var httpClient = HttpClient.newHttpClient();
+            var url = "https://api.coinbase.com/v2/currencies";
+            var request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .build();
+            var response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            var mapper = new ObjectMapper();
+            var jsonNode = mapper.readTree(response.body());
+            var dataNode = jsonNode.get("data");
+            dataNode.forEach(node -> supportedCurrencies.add(node.get("id").asText()));
+        } catch (IOException | InterruptedException e) {
+            log.severe("Failed to load supported currencies from Coinbase API: " + e.getMessage());
+        }
+    }
+
+    private void loadRates() {
+        try {
+            var httpClient = HttpClient.newHttpClient();
+            var url = "https://api.coinbase.com/v2/exchange-rates?currency=" + DEFAULT_BASE_CURRENCY;
+            var request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .build();
+            var response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            var mapper = new ObjectMapper();
+            var jsonNode = mapper.readTree(response.body());
+            var ratesNode = jsonNode.get("data").get("rates");
+            ratesNode.fields().forEachRemaining(entry -> rates.put(entry.getKey(), entry.getValue().asDouble()));
+        } catch (IOException | InterruptedException e) {
+            log.severe("Failed to load exchange rates from Coinbase API: " + e.getMessage());
+        }
+    }
+}

--- a/crypto-currency/bitcoin/src/test/java/org/javamoney/shelter/bitcoin/provider/CoinbaseRateProviderTest.java
+++ b/crypto-currency/bitcoin/src/test/java/org/javamoney/shelter/bitcoin/provider/CoinbaseRateProviderTest.java
@@ -5,7 +5,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import javax.money.UnknownCurrencyException;
 import javax.money.convert.CurrencyConversionException;
 
 import static org.junit.Assert.assertNotNull;

--- a/crypto-currency/bitcoin/src/test/java/org/javamoney/shelter/bitcoin/provider/CoinbaseRateProviderTest.java
+++ b/crypto-currency/bitcoin/src/test/java/org/javamoney/shelter/bitcoin/provider/CoinbaseRateProviderTest.java
@@ -6,6 +6,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import javax.money.UnknownCurrencyException;
+import javax.money.convert.CurrencyConversionException;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
@@ -16,7 +17,7 @@ public class CoinbaseRateProviderTest {
     @BeforeClass
     public static void setUpBeforeClass() {
         coinbaseRateProvider = new CoinbaseRateProvider();
-        CurrencyUnitBuilder.of("BTC", "BitcoinProvider")
+        CurrencyUnitBuilder.of("BTC", "CoinbaseRateProvider")
                 .setDefaultFractionDigits(8)
                 .build(true);
     }
@@ -32,7 +33,12 @@ public class CoinbaseRateProviderTest {
     }
 
     @Test
-    public void testGetExchangeRateWithInvalidCurrency() {
-        assertThrows(UnknownCurrencyException.class, () -> coinbaseRateProvider.getExchangeRate("BTC", "INVALID"));
+    public void testGetExchangeRateWithNotSupportedBaseCurrency() {
+        assertThrows(CurrencyConversionException.class, () -> coinbaseRateProvider.getExchangeRate("USD", "BTC"));
+    }
+
+    @Test
+    public void testGetExchangeRateWithNotSupportedTermCurrency() {
+        assertThrows(CurrencyConversionException.class, () -> coinbaseRateProvider.getExchangeRate("BTC", "ZWL"));
     }
 }

--- a/crypto-currency/bitcoin/src/test/java/org/javamoney/shelter/bitcoin/provider/CoinbaseRateProviderTest.java
+++ b/crypto-currency/bitcoin/src/test/java/org/javamoney/shelter/bitcoin/provider/CoinbaseRateProviderTest.java
@@ -1,0 +1,38 @@
+package org.javamoney.shelter.bitcoin.provider;
+
+import org.javamoney.moneta.CurrencyUnitBuilder;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.money.UnknownCurrencyException;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+
+public class CoinbaseRateProviderTest {
+    private static CoinbaseRateProvider coinbaseRateProvider;
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        coinbaseRateProvider = new CoinbaseRateProvider();
+        CurrencyUnitBuilder.of("BTC", "BitcoinProvider")
+                .setDefaultFractionDigits(8)
+                .build(true);
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() {
+        coinbaseRateProvider = null;
+    }
+
+    @Test
+    public void testGetExchangeRate() {
+        assertNotNull(coinbaseRateProvider.getExchangeRate("BTC", "USD"));
+    }
+
+    @Test
+    public void testGetExchangeRateWithInvalidCurrency() {
+        assertThrows(UnknownCurrencyException.class, () -> coinbaseRateProvider.getExchangeRate("BTC", "INVALID"));
+    }
+}


### PR DESCRIPTION
This PR introduces the `CoinbaseRateProvider` class, addressing the issue raised in issue [#3](https://github.com/JavaMoney/javamoney-shelter/issues/3), which highlights the need for new `ExchangeRateProvider` implementations following the discontinuation of MtGox.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/JavaMoney/javamoney-shelter/42)
<!-- Reviewable:end -->
